### PR TITLE
Fix build.sh to use BUILD_PREFIX/bin/tclsh for osx-arm64

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,8 +27,7 @@ fi
             --enable-threadsafe \
             --enable-load-extension \
             --disable-static \
-            --dynlink-tools \
-            --with-tclsh="${PREFIX}/bin/tclsh" \
+            --with-tclsh="${BUILD_PREFIX}/bin/tclsh" \
             CFLAGS="${CFLAGS} ${OPTIONS} -I${PREFIX}/include" \
             LDFLAGS="${LDFLAGS} -L${PREFIX}/lib" \
             ${PPC64LE}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: 091eeec3ae2ccb91aac21d0e9a4a58944fb2cb112fa67bffc3e08c2eca2d85c8
 
 build:
-  skip: true  # [osx and arm64]
+  skip: true  # [win and arm64]
   number: 0
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
